### PR TITLE
style: smaller menu in mobile sidebar, no line breaks in table head

### DIFF
--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -34,13 +34,27 @@ export default async function Users({
         <TableHeader>
           <TableRow>
             <TableHead>Name</TableHead>
-            <TableHead>Expected Hours Sun</TableHead>
-            <TableHead>Expected Hours Mon</TableHead>
-            <TableHead>Expected Hours Tues</TableHead>
-            <TableHead>Expected Hours Wed</TableHead>
-            <TableHead>Expected Hours Thu</TableHead>
-            <TableHead>Expected Hours Fri</TableHead>
-            <TableHead>Expected Hours Sat</TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Sun
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Mon
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Tues
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Wed
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Thu
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Fri
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
+              Expected Hours Sat
+            </TableHead>
           </TableRow>
         </TableHeader>
         {users ? (

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -65,7 +65,7 @@ export default function Header({
             <span className="sr-only">Toggle navigation menu</span>
           </Button>
         </SheetTrigger>
-        <SheetContent side="left" className="flex flex-col">
+        <SheetContent side="left" className="flex flex-col px-3">
           <SheetHeader>
             <SheetTitle>
               <VisuallyHidden.Root>Sandbox HRMS</VisuallyHidden.Root>
@@ -74,7 +74,7 @@ export default function Header({
               <VisuallyHidden.Root>Sidebar menus</VisuallyHidden.Root>
             </SheetDescription>
           </SheetHeader>
-          <nav className="grid items-start text-sm font-medium lg:px-4">
+          <nav className="grid items-start text-sm font-medium">
             <Link
               href="/"
               className={active === "dashboard" ? activeLink : inactiveLink}

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -74,7 +74,7 @@ export default function Header({
               <VisuallyHidden.Root>Sidebar menus</VisuallyHidden.Root>
             </SheetDescription>
           </SheetHeader>
-          <nav className="grid gap-2 text-lg font-medium">
+          <nav className="grid items-start text-sm font-medium lg:px-4">
             <Link
               href="/"
               className={active === "dashboard" ? activeLink : inactiveLink}

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -65,7 +65,7 @@ export default function Header({
             <span className="sr-only">Toggle navigation menu</span>
           </Button>
         </SheetTrigger>
-        <SheetContent side="left" className="flex flex-col px-3">
+        <SheetContent side="left" className="flex flex-col p-3 pt-2">
           <SheetHeader>
             <SheetTitle>
               <VisuallyHidden.Root>Sandbox HRMS</VisuallyHidden.Root>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8e7d1cd2-1b64-4805-9bcd-da49eb894c87)

